### PR TITLE
PR: Update pyproject to properly get the version dynamically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "spyder-kernels >= 3.0.0b7,<3.0.0b8",
 ]
 
+[tool.setuptools.dynamic]
+version = {attr = "spyder_remote_services.__version__"}
+
 [project.scripts]
 spyder-remote-server = "spyder_remote_services.__main__:main"
 


### PR DESCRIPTION
To use the `dynamic = ["version"]` entry it needs to be specified where the `version` is located at `[tool.setuptools.dynamic]`